### PR TITLE
ChatSpaceのDB設計

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# README
+<!-- # README
 
 This README would normally document whatever steps are necessary to get the
 application up and running.
@@ -21,4 +21,56 @@ Things you may want to cover:
 
 * Deployment instructions
 
-* ...
+* ... -->
+
+## usersテーブル
+
+|Column|Type|Options|
+|------|----|-------|
+|user_name|string|null: false, add_index: true|
+|email|string|null: false, unique: true|
+|password|string|null: false|
+
+### Association
+- has_many :groups_users
+- has_many :groups, through: :groups_users
+- has_many :messages
+
+
+## groupsテーブル
+
+|Column|Type|Options|
+|------|----|-------|
+|group_name|string|null: false, unique: true|
+
+### Association
+- has_many :groups_users
+- has_many :users, through: :groups_users
+- has_many :messages
+
+
+## messagesテーブル
+
+|Column|Type|Options|
+|------|----|-------|
+|body|text|null: false|
+|image|string||
+|user_id|integer|null: false, foreign_key: true|
+|group_id|integer|null: false, foreign_key: true|
+
+### Association
+- belongs_to :group
+- belongs_to :user
+
+
+## groups_usersテーブル
+
+|Column|Type|Options|
+|------|----|-------|
+|user_id|integer|null: false, foreign_key: true|
+|group_id|integer|null: false, foreign_key: true|
+
+### Association
+- belongs_to :group
+- belongs_to :user
+

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Things you may want to cover:
 
 |Column|Type|Options|
 |------|----|-------|
-|user_name|string|null: false, add_index: true|
+|name|string|null: false, index: true|
 |email|string|null: false, unique: true|
 |password|string|null: false|
 
@@ -41,7 +41,7 @@ Things you may want to cover:
 
 |Column|Type|Options|
 |------|----|-------|
-|group_name|string|null: false, unique: true|
+|name|string|null: false, unique: true|
 
 ### Association
 - has_many :groups_users
@@ -53,7 +53,7 @@ Things you may want to cover:
 
 |Column|Type|Options|
 |------|----|-------|
-|body|text|null: false|
+|body|text||
 |image|string||
 |user_id|integer|null: false, foreign_key: true|
 |group_id|integer|null: false, foreign_key: true|


### PR DESCRIPTION
#What
ChatSpaceで使用するデータベースの設計。
usersテーブル、groupsテーブル、messagesテーブル、
およびuserとgroupの多対多のリレーション設定のため、中間テーブルとなるusers_groupsテーブルを設計。
各テーブルについて、カラム名、データ型、オプション設定を記述。
またテーブル間リレーションを示すアソシエーションの設定を記述した。

#Why
ChatSpaceの実装に先立つデータベースの設計